### PR TITLE
Add support for devcontainer environments

### DIFF
--- a/.devcontainer/nvhpc/Dockerfile
+++ b/.devcontainer/nvhpc/Dockerfile
@@ -1,0 +1,28 @@
+FROM nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu24.04 AS cuda-base
+
+RUN apt update && apt install -y git curl libcurl4-openssl-dev
+
+WORKDIR /src/hdf5
+COPY .devcontainer/scripts/install_hdf5.sh .
+RUN ./install_hdf5.sh "/usr/local/hdf5"
+
+# NOTE(cmo): Based on https://github.com/adalundhe/dev-images/blob/main/cpp/Dockerfile.cpp
+ARG USERNAME=devcontainer
+ARG USER_UID=5000
+ARG USER_GID=$USER_UID
+
+# https://happihacking.com/blog/posts/2024/dev-containers-uids/ for 24.04
+RUN userdel -r ubuntu
+
+RUN apt install -y sudo
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && adduser --disabled-password --gecos "" --uid $USER_UID --gid $USER_GID $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+ENV HOME=/home/$USERNAME
+USER $USERNAME
+
+ENV HDF5_ROOT="/usr/local/hdf5"
+ENV HDF5_USE_FILE_LOCKING=FALSE

--- a/.devcontainer/nvhpc/Dockerfile
+++ b/.devcontainer/nvhpc/Dockerfile
@@ -1,4 +1,8 @@
-FROM nvcr.io/nvidia/nvhpc:25.5-devel-cuda12.9-ubuntu24.04 AS cuda-base
+FROM nvcr.io/nvidia/nvhpc:24.5-devel-cuda12.4-ubuntu22.04 AS cuda-base
+# NOTE(cmo): Somewhere along the line cmake/nvcc started using --option-file for
+# specifying paths and flags, and this doens't seem supported by
+# intellisense/compile_commands.json. This is fine in 24.5, which is relatively
+# on par with most HPC too.
 
 RUN apt update && apt install -y git curl libcurl4-openssl-dev
 
@@ -6,15 +10,20 @@ WORKDIR /src/hdf5
 COPY .devcontainer/scripts/install_hdf5.sh .
 RUN ./install_hdf5.sh "/usr/local/hdf5"
 
+WORKDIR /src/kokkos
+COPY .devcontainer/scripts/kokkos/*.sh .
+RUN ./default_cuda_setup_debug.sh
+RUN ./default_cuda_setup.sh
+
 # NOTE(cmo): Based on https://github.com/adalundhe/dev-images/blob/main/cpp/Dockerfile.cpp
 ARG USERNAME=devcontainer
 ARG USER_UID=5000
 ARG USER_GID=$USER_UID
 
 # https://happihacking.com/blog/posts/2024/dev-containers-uids/ for 24.04
-RUN userdel -r ubuntu
+# RUN userdel -r ubuntu
 
-RUN apt install -y sudo
+RUN apt update && apt install -y sudo
 
 RUN groupadd --gid $USER_GID $USERNAME \
     && adduser --disabled-password --gecos "" --uid $USER_UID --gid $USER_GID $USERNAME \
@@ -25,4 +34,6 @@ ENV HOME=/home/$USERNAME
 USER $USERNAME
 
 ENV HDF5_ROOT="/usr/local/hdf5"
+ENV Kokkos_ROOT="/usr/local/kokkos"
+ENV CUDA_DEVCONTAINER=1
 ENV HDF5_USE_FILE_LOCKING=FALSE

--- a/.devcontainer/nvhpc/devcontainer.json
+++ b/.devcontainer/nvhpc/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "../..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "./Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+                "ms-vscode.cmake-tools",
+                "ms-vscode.cpptools",
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "ubuntu",
+	"updateRemoteUserUID": true,
+
+	"runArgs": [
+    "--gpus",
+    "all"
+]
+}

--- a/.devcontainer/scripts/install_hdf5.sh
+++ b/.devcontainer/scripts/install_hdf5.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Call with installation prefix as arg 1
+if [ -z "$1" ]; then
+    echo "Using default HDF5 installation prefix"
+else
+    # PREFIX="--prefix=$1"
+    PREFIX="-DCMAKE_INSTALL_PREFIX=$1"
+    echo "Setting HDF5 installation prefix to $1"
+fi
+
+HDF_VERSION="1.14.6"
+rm -rf "hdf5-${HDF_VERSION}*"
+rm -rf hdfsrc
+
+wget "https://github.com/HDFGroup/hdf5/releases/download/hdf5_${HDF_VERSION}/hdf5-${HDF_VERSION}.tar.gz"
+tar xvzf "hdf5-${HDF_VERSION}.tar.gz"
+cd hdf5-${HDF_VERSION}
+# ./configure CC=$(which mpicc) --enable-parallel --with-default-api-version=v110 ${PREFIX}
+mkdir build
+cd build
+cmake -DCMAKE_C_COMPILER=$(which mpicc) -DHDF5_ENABLE_PARALLEL=On -DBUILD_CPP_LIB=On -DDEFAULT_API_VERSION="v112" ${PREFIX} ..
+make -j 10
+make install

--- a/.devcontainer/scripts/kokkos/default_cuda_setup.sh
+++ b/.devcontainer/scripts/kokkos/default_cuda_setup.sh
@@ -1,0 +1,12 @@
+
+    #  -DCMAKE_CXX_COMPILER=mpicxx \
+./install.sh \
+    "-DKokkos_ENABLE_SERIAL=ON \
+     -DKokkos_ENABLE_OPENMP=OFF \
+     -DKokkos_ENABLE_CUDA=ON \
+     -DKokkos_ARCH_ADA89=ON \
+     -DKokkos_ENABLE_CUDA_CONSTEXPR=ON \
+     -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON \
+     -DCMAKE_CXX_COMPILER=g++ \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DCMAKE_INSTALL_PREFIX=/usr/local/kokkos"

--- a/.devcontainer/scripts/kokkos/default_cuda_setup_debug.sh
+++ b/.devcontainer/scripts/kokkos/default_cuda_setup_debug.sh
@@ -1,0 +1,14 @@
+
+./install.sh \
+    "-DKokkos_ENABLE_SERIAL=ON \
+     -DKokkos_ENABLE_OPENMP=OFF \
+     -DKokkos_ENABLE_CUDA=ON \
+     -DKokkos_ARCH_ADA89=ON \
+     -DKokkos_ENABLE_CUDA_CONSTEXPR=ON \
+     -DKokkos_ENABLE_CUDA_LAMBDA=ON \
+     -DKokkos_ENABLE_DEBUG=ON \
+     -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON \
+     -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON \
+     -DCMAKE_CXX_COMPILER=g++ \
+     -DCMAKE_BUILD_TYPE=Debug \
+     -DCMAKE_INSTALL_PREFIX=/usr/local/kokkos-debug"

--- a/.devcontainer/scripts/kokkos/install.sh
+++ b/.devcontainer/scripts/kokkos/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+KOKKOS_VERSION="4.6.02"
+
+rm -rf kokkos-${KOKKOS_VERSION}
+
+# Call with $1 as a string of CMake flags e.g. -DKOKKOS_ENABLE_CUDA=ON
+wget -O kokkos.tar.gz https://github.com/kokkos/kokkos/releases/download/${KOKKOS_VERSION}/kokkos-${KOKKOS_VERSION}.tar.gz
+tar xvzf kokkos.tar.gz
+cd kokkos-${KOKKOS_VERSION}
+mkdir build
+cd build
+cmake $1 ..
+make -j 10
+make install

--- a/.devcontainer/ubuntu-24.04/Dockerfile
+++ b/.devcontainer/ubuntu-24.04/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/devcontainers/cpp:dev-ubuntu-24.04
+
+RUN apt update && apt install -y git curl libcurl4-openssl-dev libopenmpi-dev
+
+WORKDIR /src/hdf5
+COPY .devcontainer/scripts/install_hdf5.sh .
+RUN ./install_hdf5.sh "/usr/local/hdf5"
+
+# NOTE(cmo): Based on https://github.com/adalundhe/dev-images/blob/main/cpp/Dockerfile.cpp
+ARG USERNAME=devcontainer
+ARG USER_UID=5000
+ARG USER_GID=$USER_UID
+
+# https://happihacking.com/blog/posts/2024/dev-containers-uids/ for 24.04
+RUN apt install -y sudo
+
+ENV HDF5_ROOT="/usr/local/hdf5"
+ENV HDF5_USE_FILE_LOCKING=FALSE

--- a/.devcontainer/ubuntu-24.04/devcontainer.json
+++ b/.devcontainer/ubuntu-24.04/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "../..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "./Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+                "ms-vscode.cmake-tools",
+                "ms-vscode.cpptools",
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "vscode",
+	"updateRemoteUserUID": true,
+
+	"runArgs": []
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 option(USE_KOKKOS_CUDA "Enable Kokkos with CUDA backend" OFF)
 option(USE_KOKKOS_HIP "Enable Kokkos with HIP backend" OFF)
@@ -49,7 +49,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS on)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -mtune=native -g -fopenmp -DUSE_HDF5")
-find_package(HDF5 REQUIRED COMPONENTS CXX)
+find_package(HDF5 REQUIRED)
 
 set(SAMS_SOURCES
   src/main.cpp
@@ -82,7 +82,7 @@ endif()
 
 add_executable(sams ${SAMS_SOURCES})
 message(STATUS "CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
-  
+
 
 target_include_directories(sams PRIVATE ${HDF5_INCLUDE_DIRS})
 target_include_directories(sams PRIVATE "${CMAKE_SOURCE_DIR}/src/PhysicsPackages/LARE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.18)
 
 option(USE_KOKKOS_CUDA "Enable Kokkos with CUDA backend" OFF)
 option(USE_KOKKOS_HIP "Enable Kokkos with HIP backend" OFF)
@@ -6,19 +6,24 @@ option(USE_KOKKOS_SYCL "Enable Kokkos with SYCL backend" OFF)
 option(USE_KOKKOS_OPENMP "Enable Kokkos with OpenMP backend" OFF)
 option(USE_NATIVE_CUDA "Compile all .cpp files with nvcc as CUDA" OFF)
 
+set(USE_KOKKOS False)
 if(USE_KOKKOS_CUDA)
+  set(USE_KOKKOS True)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKOKKOS_CUDA")
 endif()
 
 if(USE_KOKKOS_HIP)
+  set(USE_KOKKOS True)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKOKKOS_HIP")
 endif()
 
 if(USE_KOKKOS_SYCL)
+  set(USE_KOKKOS True)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKOKKOS_SYCL")
 endif()
 
 if(USE_KOKKOS_OPENMP)
+  set(USE_KOKKOS True)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp -DKOKKOS_OPENMP")
 endif()
 
@@ -26,7 +31,7 @@ if(USE_NATIVE_CUDA)
   enable_language(CUDA)
   set(CMAKE_CUDA_STANDARD 20)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-  set(CMAKE_CUDA_EXTENSIONS on)
+  set(CMAKE_CUDA_EXTENSIONS ON)
   set(CMAKE_CUDA_ARCHITECTURES native)
 endif()
 
@@ -34,7 +39,7 @@ if(USE_NATIVE_HIP)
   enable_language(HIP)
   set(CMAKE_HIP_STANDARD 20)
   set(CMAKE_HIP_STANDARD_REQUIRED ON)
-  set(CMAKE_HIP_EXTENSIONS on)
+  set(CMAKE_HIP_EXTENSIONS ON)
   set(CMAKE_HIP_ARCHITECTURES native)
 endif()
 
@@ -48,8 +53,28 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS on)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -mtune=native -g -fopenmp -DUSE_HDF5")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -DUSE_HDF5")
 find_package(HDF5 REQUIRED)
+
+if (USE_KOKKOS)
+  enable_language(CXX)
+  find_package(Kokkos REQUIRED CONFIG)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_KOKKOS")
+  # NOTE(cmo): Kokkos compiling source as CUDA gives the best
+  # kokkos/vscode/devcontainer intellisense experience.
+  if (${Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE})
+    enable_language(${Kokkos_COMPILE_LANGUAGE})
+    # NOTE(cmo): Hack for older CMake versions
+    if (NOT DEFINED CMAKE_CUDA20_STANDARD_COMPILE_OPTION)
+      set(CMAKE_CUDA20_STANDARD_COMPILE_OPTION "-std=c++20")
+    endif()
+    set(CMAKE_${Kokkos_COMPILE_LANGUAGE}_FLAGS "${CMAKE_${Kokkos_COMPILE_LANGUAGE}_FLAGS} ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES})
+    set(CMAKE_${Kokkos_COMPILE_LANGUAGE}_STANDARD ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_STANDARD})
+  endif()
+elseif(NOT (USE_NATIVE_CUDA OR USE_NATIVE_HIP))
+  find_package(OpenMP REQUIRED)
+endif()
 
 set(SAMS_SOURCES
   src/main.cpp
@@ -90,8 +115,16 @@ target_include_directories(sams PRIVATE "${CMAKE_SOURCE_DIR}/src/PhysicsPackages
 target_include_directories(sams PRIVATE "${CMAKE_SOURCE_DIR}/include/harness")
 target_link_libraries(sams PRIVATE ${HDF5_LIBRARIES})
 
-if (USE_KOKKOS_CUDA OR USE_KOKKOS_HIP OR USE_KOKKOS_SYCL OR USE_KOKKOS_OPENMP)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_KOKKOS")
-  find_package(Kokkos REQUIRED)
+if (NOT (USE_KOKKOS OR USE_NATIVE_CUDA OR USE_NATIVE_HIP))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -mtune=native")
+  target_link_libraries(sams PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+if (USE_KOKKOS)
+  if (${Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE})
+    foreach(src_file IN LISTS SAMS_SOURCES)
+      set_source_files_properties(${src_file} PROPERTIES LANGUAGE ${Kokkos_COMPILE_LANGUAGE})
+    endforeach()
+  endif()
   target_link_libraries(sams PRIVATE Kokkos::kokkos)
 endif()


### PR DESCRIPTION
This PR adds a couple of basic [devcontainers](https://containers.dev/) that support building SAMS and working on it with intellisense in vscode, with the minimal amount of pain, i.e. install docker, select an image, and hit go. Due to being container-based, these are useful for ensuring environmental consistency.
Additionally, adjusted `CMakeLists.txt` to support this, and not explode when using `Kokkos_COMPILE_AS_CMAKE_LANGUAGE`, which gives the best Kokkos intellisense experience IME.