### PR TITLE
Move timestep calculation to start of step

### DIFF
--- a/include/runner/runner.h
+++ b/include/runner/runner.h
@@ -146,6 +146,7 @@ namespace SAMS
         FULL_CALL_X(setBoundaryConditions); //Set boundary conditions
         FULL_CALL_X(defaultVariables); //Set default variable values
 
+        FULL_CALL_X(beforeStartOfTimestep); //Actions just before the step starts
         FULL_CALL_X(startOfTimestep); //Actions to perform at the start of each timestep
         FULL_CALL_X(halfTimestep); //Actions to perform at half timestep
         FULL_CALL_X(endOfTimestep); //Actions to perform at end of timestep
@@ -567,6 +568,7 @@ namespace SAMS
                 if (step%10 == 0){
                     SAMS::cout << "Starting timestep " << step << " at time " << std::get<timeState>(runnerData).time <<  ", dt = " << std::get<timeState>(runnerData).dt << std::endl;
                 }
+                beforeStartOfTimestep(); //Set timestep value
                 calculateTimestep(); //Set timestep value
                 startOfTimestep(); //Start of timestep (predictor)
                 halfTimestep(); //Half timestep (correction)

--- a/include/runner/runner.h
+++ b/include/runner/runner.h
@@ -567,6 +567,7 @@ namespace SAMS
                 if (step%10 == 0){
                     SAMS::cout << "Starting timestep " << step << " at time " << std::get<timeState>(runnerData).time <<  ", dt = " << std::get<timeState>(runnerData).dt << std::endl;
                 }
+                calculateTimestep(); //Set timestep value
                 startOfTimestep(); //Start of timestep (predictor)
                 halfTimestep(); //Half timestep (correction)
                 auto& tData = std::get<timeState>(runnerData);

--- a/src/PhysicsPackages/LARE/lagran.cpp
+++ b/src/PhysicsPackages/LARE/lagran.cpp
@@ -63,7 +63,7 @@ namespace LARE
 }
 
     template<typename T_EOS>
-    void LARE3D<T_EOS>::lagrangian_step(simulationData &data, SAMS::controlFunctions &controlFns)
+    void LARE3D<T_EOS>::lagrangian_step(simulationData &data)
     {   
         using Range = pw::Range;
 
@@ -136,7 +136,7 @@ namespace LARE
                         xbp, ybp, zbp);
 
         shock_viscosity(data);
-        controlFns.calculateTimestep();
+
         if (data.resistiveMHD)
         {
             T_dataType dt_sub = data.dtr;

--- a/src/PhysicsPackages/LARE/lagran.cpp
+++ b/src/PhysicsPackages/LARE/lagran.cpp
@@ -63,7 +63,7 @@ namespace LARE
 }
 
     template<typename T_EOS>
-    void LARE3D<T_EOS>::lagrangian_step(simulationData &data)
+    void LARE3D<T_EOS>::lagrangian_prepare(simulationData &data)
     {   
         using Range = pw::Range;
 
@@ -136,6 +136,10 @@ namespace LARE
                         xbp, ybp, zbp);
 
         shock_viscosity(data);
+    }
+    template<typename T_EOS>
+    void LARE3D<T_EOS>::lagrangian_step(simulationData &data)
+    {
 
         if (data.resistiveMHD)
         {

--- a/src/PhysicsPackages/LARE/shared_data.h
+++ b/src/PhysicsPackages/LARE/shared_data.h
@@ -412,6 +412,9 @@ namespace LARE
             grid(data);
         }
 
+        void beforeStartOfTimestep(simulationData &data){
+            lagrangian_prepare(data);
+        }
         /**
          * Physics timestep functions
          * This is the predictor step of the LARE3D timestep
@@ -536,6 +539,11 @@ namespace LARE
         void z_energy_flux(simulationData &data, remapData &remap_data);
         template <auto mPtr>
         void z_mom_flux(simulationData &data, remapData &remap_data);
+
+        /**
+         * First part of Lagrangian step for the LARE3D
+         */
+        void lagrangian_prepare(simulationData &data);
 
         /**
          * Lagrangian step for the LARE3D

--- a/src/PhysicsPackages/LARE/shared_data.h
+++ b/src/PhysicsPackages/LARE/shared_data.h
@@ -417,8 +417,8 @@ namespace LARE
          * This is the predictor step of the LARE3D timestep
          * @param data LARE3D simulation data
          */
-        void startOfTimestep(simulationData &data, SAMS::controlFunctions &controlFns){
-            lagrangian_step(data, controlFns);
+        void startOfTimestep(simulationData &data){
+            lagrangian_step(data);
         }
 
         /**
@@ -542,7 +542,7 @@ namespace LARE
          * @param data Simulation data struct
          * This function performs a Lagrangian step for the LARE3D
          */
-        void lagrangian_step(simulationData &data, SAMS::controlFunctions &controlFns);
+        void lagrangian_step(simulationData &data);
 
         /**
          * Calculate the resistivity eta based on current density


### PR DESCRIPTION
This _should_ be fine, but need to be aware of issues if starting with strong stationary shock as LARE will not now calculate the shock_viscosity before setting this. 