### PR TITLE
Allocations done once

### DIFF
--- a/src/PhysicsPackages/LARE/remap.cpp
+++ b/src/PhysicsPackages/LARE/remap.cpp
@@ -24,16 +24,6 @@ namespace LARE
     {
         using Range = pw::Range;
         int case_test;
-        pw::portableArrayManager remapManager;
-
-        // We can allocate everything other than flux here
-        remapManager.allocate(remap_data.rho1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
-        remapManager.allocate(remap_data.cv2, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
-        remapManager.allocate(remap_data.cvc1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
-        remapManager.allocate(remap_data.db1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
-        remapManager.allocate(remap_data.rho_v, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
-        remapManager.allocate(remap_data.rho_v1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
-        // Flux is one element larger in the direction of remap, so it is allocated in each remap function
 
         if (data.rke)
         {
@@ -102,12 +92,6 @@ namespace LARE
         data.y(ix, iy, iz) = data.yb(iy);
         data.z(ix, iy, iz) = data.zb(iz); }, Range(-2, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
 
-        remapManager.deallocate(remap_data.rho1);
-        remapManager.deallocate(remap_data.cv2);
-        remapManager.deallocate(remap_data.cvc1);
-        remapManager.deallocate(remap_data.db1);
-        remapManager.deallocate(remap_data.rho_v);
-        remapManager.deallocate(remap_data.rho_v1);
     }
     #include "./instantiate.h"
 }

--- a/src/PhysicsPackages/LARE/setup.cpp
+++ b/src/PhysicsPackages/LARE/setup.cpp
@@ -259,6 +259,32 @@ namespace LARE
         data.eos.setGamma(data.gas_gamma);
     }
 
+    template<typename T_EOS>
+    void LARE3D<T_EOS>::allocate_remap(SAMS::harness &harness, simulationData &data, remapData & remap_data)
+    {
+        T_sizeType nx, ny, nz;
+        using Range = pw::Range;
+
+        auto &axRegistry = harness.axisRegistry;
+        auto &varRegistry = harness.variableRegistry;
+        auto &remapManager = harness.memoryRegistry.getArrayManager();
+        // Centred since LARE thinks in terms of cell centres for nx, ny, nz
+        nx = axRegistry.getLocalDomainElements("X", SAMS::staggerType::CENTRED);
+        ny = axRegistry.getLocalDomainElements("Y", SAMS::staggerType::CENTRED);
+        nz = axRegistry.getLocalDomainElements("Z", SAMS::staggerType::CENTRED);
+
+        //Could use registry for all these also
+        remapManager.allocate(remap_data.rho1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
+        remapManager.allocate(remap_data.cv2, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
+        remapManager.allocate(remap_data.cvc1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
+        remapManager.allocate(remap_data.db1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
+        remapManager.allocate(remap_data.rho_v, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
+        remapManager.allocate(remap_data.rho_v1, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
+
+        //Flux now made large enough on all dimensions
+        remapManager.allocate(remap_data.flux, Range(-2, data.nx + 2), Range(-2, data.ny + 2), Range(-2, data.nz + 2));
+
+    }
     /**
      * Setup the basic LARE3D parameters like grid points etc.
      */

--- a/src/PhysicsPackages/LARE/shared_data.h
+++ b/src/PhysicsPackages/LARE/shared_data.h
@@ -409,8 +409,9 @@ namespace LARE
          * @param harnessRef SAMS harness
          * @param data LARE3D simulation data
          */
-        void getVariables(SAMS::harness &harnessRef, simulationData &data){
+        void getVariables(SAMS::harness &harnessRef, simulationData &data, remapData &remap_data){
             allocate(harnessRef, data);
+            allocate_remap(harnessRef, data, remap_data);
             grid(data);
         }
 
@@ -484,6 +485,14 @@ namespace LARE
          * It uses the portableArrayManager to handle the memory allocation and deallocation.
          */
         void allocate(SAMS::harness &harness, simulationData &data);
+
+        /**
+         * Allocate permanent arrays for remap
+         * @param harness SAMS harness
+         * @param data Remap data struct
+         * It uses the portableArrayManager to handle the memory allocation and deallocation.
+         */
+        void allocate_remap(SAMS::harness &harness, simulationData &data, remapData &remap_data);
 
         /**
          * Setup the LARE3D data

--- a/src/PhysicsPackages/LARE/xremap.cpp
+++ b/src/PhysicsPackages/LARE/xremap.cpp
@@ -8,10 +8,6 @@ namespace LARE
     void LARE3D<T_EOS>::remap_x(simulationData &data, remapData &remap_data)
     {
         using Range = pw::Range;
-        pw::portableArrayManager xRemapManager;
-        remap_data.flux.nullify();
-
-        xRemapManager.allocate(remap_data.flux, Range(-2, data.nx + 2), Range(-1, data.ny + 2), Range(-1, data.nz + 2));
 
         pw::assign(data.dm, 0.0);
         pw::assign(remap_data.rho1, data.rho);

--- a/src/PhysicsPackages/LARE/yremap.cpp
+++ b/src/PhysicsPackages/LARE/yremap.cpp
@@ -8,10 +8,6 @@ namespace LARE
     void LARE3D<T_EOS>::remap_y(simulationData &data, remapData &remap_data)
     {
         using Range = pw::Range;
-        pw::portableArrayManager yRemapManager;
-        remap_data.flux.nullify();
-
-        yRemapManager.allocate(remap_data.flux, Range(-1, data.nx + 2), Range(-2, data.ny + 2), Range(-1, data.nz + 2));
 
         pw::assign(data.dm, 0.0);
         pw::assign(remap_data.rho1, data.rho);

--- a/src/PhysicsPackages/LARE/zremap.cpp
+++ b/src/PhysicsPackages/LARE/zremap.cpp
@@ -8,10 +8,6 @@ namespace LARE
     void LARE3D<T_EOS>::remap_z(simulationData &data, remapData &remap_data)
     {
         using Range = pw::Range;
-        pw::portableArrayManager zRemapManager;
-        remap_data.flux.nullify();
-
-        zRemapManager.allocate(remap_data.flux, Range(-1, data.nx + 2), Range(-1, data.ny + 2), Range(-2, data.nz + 2));
 
         pw::assign(data.dm, 0.0);
         pw::assign(remap_data.rho1, data.rho);


### PR DESCRIPTION
Cursory testing on GPU suggests this can cut 2 seconds off 30seconds, so circa 5% improvement. CPU tests not inconsistent with a similar effect, I haven't done much. 